### PR TITLE
Add unified task system with retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ if (ModbusRtuMaster.isValidResponse(response)) {
 }
 ```
 
+同样的逻辑也可以通过 `CommTask` 在 `CommBridge` 中调度完成：
+
+```kotlin
+val bleManager = BleManager(appContext)
+CommBridge.initBle(bleManager)
+
+CommBridge.sendTask(
+    SerialTask("device1", "/dev/ttyS1", byteArrayOf(0x00))
+)
+```
+
 🧠 环境要求
 Android 7.0+
 

--- a/app/src/main/java/com/sik/sikcomm/MainActivity.kt
+++ b/app/src/main/java/com/sik/sikcomm/MainActivity.kt
@@ -6,6 +6,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.sik.comm.core.CommBridge
+import com.sik.comm.bluetooth.BleManager
+import com.sik.comm.task.SerialTask
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -18,7 +20,12 @@ class MainActivity : AppCompatActivity() {
             insets
         }
 
-        // Demo call to library
-        CommBridge.sendTask("demo", byteArrayOf(0x00))
+        val bleManager = BleManager(applicationContext)
+        CommBridge.initBle(bleManager)
+
+        // Demo call to library using the new task interface
+        CommBridge.sendTask(
+            SerialTask("demo", "/dev/ttyS1", byteArrayOf(0x00))
+        )
     }
 }

--- a/sikcomm/src/main/java/com/sik/comm/bluetooth/BleManager.kt
+++ b/sikcomm/src/main/java/com/sik/comm/bluetooth/BleManager.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.asStateFlow
  * It does not hold any Activity or Fragment context.
  */
 class BleManager(applicationContext: Context) {
+    private val context = applicationContext.applicationContext
     private val adapter: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter()
     private val _scannedDevices = MutableStateFlow<List<BluetoothDevice>>(emptyList())
     val scannedDevices = _scannedDevices.asStateFlow()
@@ -18,5 +19,15 @@ class BleManager(applicationContext: Context) {
     fun startScan() {
         val list = adapter?.bondedDevices?.toList() ?: emptyList()
         _scannedDevices.value = list
+    }
+
+    /**
+     * Placeholder send implementation. In real code this would handle
+     * connecting and writing to the BLE characteristic identified by
+     * [mac].
+     */
+    fun send(mac: String, data: ByteArray): Boolean {
+        // No real BLE operations implemented yet
+        return adapter != null && mac.isNotEmpty() && data.isNotEmpty()
     }
 }

--- a/sikcomm/src/main/java/com/sik/comm/core/CommBridge.kt
+++ b/sikcomm/src/main/java/com/sik/comm/core/CommBridge.kt
@@ -1,14 +1,60 @@
 package com.sik.comm.core
 
 import com.sik.comm.device.DeviceManager
+import com.sik.comm.serial.SerialPortIO
+import com.sik.comm.bluetooth.BleManager
+import com.sik.comm.task.BleTask
+import com.sik.comm.task.CommTask
+import com.sik.comm.task.SerialTask
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 /**
  * Unified communication entry that schedules tasks.
  */
 object CommBridge {
-    fun sendTask(deviceId: String, data: ByteArray) {
-        // Just mark device as seen in this demo implementation
-        DeviceManager.updateDevice(deviceId)
-        // Real sending logic should be implemented here
+    private val executor = Executors.newSingleThreadExecutor()
+    private var bleManager: BleManager? = null
+
+    fun initBle(manager: BleManager) {
+        bleManager = manager
+    }
+
+    /**
+     * Submit [task] for execution. The task will run on a background thread
+     * and be retried if it fails.
+     */
+    fun sendTask(task: CommTask, retries: Int = 3, delayMs: Long = 100) {
+        executor.execute {
+            var attempt = 0
+            while (attempt < retries) {
+                DeviceManager.updateDevice(task.deviceId)
+                val success = when (task) {
+                    is SerialTask -> handleSerial(task)
+                    is BleTask -> handleBle(task)
+                }
+                if (success) break
+                attempt++
+                if (attempt < retries) {
+                    TimeUnit.MILLISECONDS.sleep(delayMs)
+                }
+            }
+        }
+    }
+
+    private fun handleSerial(task: SerialTask): Boolean {
+        return try {
+            val io = SerialPortIO(task.portPath)
+            io.clearInput()
+            io.write(task.payload)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun handleBle(task: BleTask): Boolean {
+        val manager = bleManager ?: return false
+        return manager.send(task.mac, task.payload)
     }
 }

--- a/sikcomm/src/main/java/com/sik/comm/task/CommTask.kt
+++ b/sikcomm/src/main/java/com/sik/comm/task/CommTask.kt
@@ -1,0 +1,23 @@
+package com.sik.comm.task
+
+/**
+ * Represents a unit of communication work. Implementations specify
+ * the target transport and data to send.
+ */
+sealed interface CommTask {
+    val deviceId: String
+}
+
+/** Task executed over a serial port */
+data class SerialTask(
+    override val deviceId: String,
+    val portPath: String,
+    val payload: ByteArray
+) : CommTask
+
+/** Task executed over BLE */
+data class BleTask(
+    override val deviceId: String,
+    val mac: String,
+    val payload: ByteArray
+) : CommTask


### PR DESCRIPTION
## Summary
- introduce `CommTask` interface with `SerialTask` and `BleTask`
- implement retry logic in `CommBridge` and choose transport based on task type
- extend `BleManager` with a stub `send` API
- update sample `MainActivity` to use the new tasks
- document new usage in README

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5dd024ac832e84a5d82d28a57aeb