### PR TITLE
Implement SerialPortIO close

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ val response = port.read(7)
 if (ModbusRtuMaster.isValidResponse(response)) {
     println("合法响应：${response.joinToString(" ") { "%02X".format(it) }}")
 }
+// 完成通信后记得关闭串口
+port.close()
 ```
 
 🧠 环境要求

--- a/sikcomm/src/main/java/com/sik/comm/serial/SerialPortIO.kt
+++ b/sikcomm/src/main/java/com/sik/comm/serial/SerialPortIO.kt
@@ -32,4 +32,22 @@ class SerialPortIO(path: String) {
         input.read(buffer)
         return buffer
     }
+
+    /**
+     * Close all underlying streams and descriptor.
+     */
+    fun close() {
+        try {
+            input.close()
+        } catch (_: Exception) {
+        }
+        try {
+            output.close()
+        } catch (_: Exception) {
+        }
+        try {
+            pfd.close()
+        } catch (_: Exception) {
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement `SerialPortIO.close` to release streams
- show closing the port in README example

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :sikcomm:assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5dcf88a0832e80941f70f20f869b