### PR TITLE
Implement Modbus protocol stack

### DIFF
--- a/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusConfig.kt
+++ b/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusConfig.kt
@@ -1,6 +1,10 @@
 package com.sik.comm.impl_modbus
 
+import com.sik.comm.codec.Crc16ModbusCodec
+import com.sik.comm.core.codec.MessageCodec
+import com.sik.comm.core.interceptor.CommInterceptor
 import com.sik.comm.core.model.ProtocolConfig
+import com.sik.comm.core.plugin.CommPlugin
 import com.sik.comm.core.protocol.ProtocolType
 
 /**
@@ -18,8 +22,17 @@ open class ModbusConfig(
     val baudRate: Int = 9600,
     val dataBits: Int = 8,
     val stopBits: Int = 1,
-    val parity: Char = 'N'
+    val parity: Char = 'N',
+    val codec: MessageCodec = Crc16ModbusCodec(),
+    val defaultUnitId: Int? = 1,
+    val requestTimeoutMs: Int = 3000,
+    val responseGapMs: Int = 30,
+    val connectTimeoutMs: Int = 5000,
+    override val additionalPlugins: List<CommPlugin> = emptyList(),
+    override val additionalInterceptors: List<CommInterceptor> = emptyList(),
+    enableMock: Boolean = false
 ) : ProtocolConfig(
     deviceId = deviceId,
-    protocolType = ProtocolType.RS485
+    protocolType = ProtocolType.RS485,
+    enableMock = enableMock
 )

--- a/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusDevice.kt
+++ b/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusDevice.kt
@@ -1,0 +1,18 @@
+package com.sik.comm.impl_modbus
+
+import com.sik.comm.core.interceptor.CommInterceptor
+import com.sik.comm.core.plugin.CommPlugin
+
+/**
+ * Modbus 单设备运行态，持有传输层、拦截器与插件。
+ */
+internal class ModbusDevice(
+    val config: ModbusConfig,
+    val transport: ModbusTransport,
+    val interceptors: List<CommInterceptor>,
+    val plugins: List<CommPlugin>
+) {
+    fun close() {
+        runCatching { transport.close() }
+    }
+}

--- a/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusMetaKeys.kt
+++ b/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusMetaKeys.kt
@@ -1,0 +1,18 @@
+package com.sik.comm.impl_modbus
+
+/**
+ * Modbus 协议使用到的 metadata 统一键值。
+ */
+object ModbusMetaKeys {
+    const val UNIT_ID = "unitId"
+    const val FUNCTION_CODE = "functionCode"
+    const val ADDRESS = "address"
+    const val QUANTITY = "quantity"
+    const val TIMEOUT = "timeoutMs"
+    const val EXPECTED_LENGTH = "expectedLength"
+    const val SILENCE_GAP = "silenceGapMs"
+    const val RAW_FRAME = "rawFrame"
+    const val RAW_PAYLOAD = "rawPayload"
+    const val CRC = "crc"
+    const val EXCEPTION_CODE = "exceptionCode"
+}

--- a/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusPluginScopes.kt
+++ b/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusPluginScopes.kt
@@ -1,0 +1,20 @@
+package com.sik.comm.impl_modbus
+
+import com.sik.comm.core.model.CommMessage
+import com.sik.comm.core.model.ProtocolState
+import com.sik.comm.core.plugin.PluginScope
+
+/**
+ * 便捷构造 Modbus 插件使用的 Scope。
+ */
+internal object ModbusPluginScopes {
+    fun scope(config: ModbusConfig, state: ProtocolState, message: CommMessage? = null): PluginScope {
+        return PluginScope(
+            deviceId = config.deviceId,
+            protocolType = config.protocolType,
+            config = config,
+            state = state,
+            message = message
+        )
+    }
+}

--- a/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusProtocol.kt
+++ b/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusProtocol.kt
@@ -1,0 +1,272 @@
+package com.sik.comm.impl_modbus
+
+import com.sik.comm.core.injection.CommInjection
+import com.sik.comm.core.interceptor.InterceptorChain
+import com.sik.comm.core.interceptor.InterceptorScope
+import com.sik.comm.core.logger.DefaultProtocolLogger
+import com.sik.comm.core.logger.ProtocolLogger
+import com.sik.comm.core.model.CommMessage
+import com.sik.comm.core.model.ProtocolState
+import com.sik.comm.core.protocol.Protocol
+import com.sik.comm.core.protocol.ProtocolType
+import com.sik.comm.core.plugin.CommPlugin
+import com.sik.comm.core.state.DeviceStateCenter
+import com.sik.comm.core.task.DeviceTaskManager
+import java.net.URI
+
+/**
+ * Modbus 协议实现，支持 RS485 与 TCP 封装。
+ */
+class ModbusProtocol(
+    private val logger: ProtocolLogger = DefaultProtocolLogger,
+    private val transportFactory: (ModbusConfig) -> ModbusTransport = { cfg ->
+        val name = cfg.portName
+        when {
+            name.startsWith("tcp://", ignoreCase = true) -> {
+                val uri = runCatching { URI.create(name) }.getOrElse { throw IllegalArgumentException("Invalid tcp url: ${cfg.portName}", it) }
+                val host = uri.host ?: error("Invalid tcp url: ${cfg.portName}")
+                val port = if (uri.port != -1) uri.port else 502
+                TcpModbusTransport(host, port, cfg.connectTimeoutMs)
+            }
+            !name.startsWith("/") && name.contains(":") -> {
+                val parts = name.split(":", limit = 2)
+                val host = parts[0]
+                val port = parts.getOrNull(1)?.toIntOrNull() ?: 502
+                TcpModbusTransport(host, port, cfg.connectTimeoutMs)
+            }
+            else -> SerialModbusTransport(cfg)
+        }
+    }
+) : Protocol {
+
+    private val devices = mutableMapOf<String, ModbusDevice>()
+    private val configs = mutableMapOf<String, ModbusConfig>()
+
+    fun registerConfig(config: ModbusConfig) {
+        configs[config.deviceId] = config
+    }
+
+    override fun connect(deviceId: String) {
+        val existing = devices[deviceId]
+        if (existing?.transport?.isOpen() == true) {
+            return
+        }
+        val cfg = requireModbusConfig(deviceId)
+        val injected = CommInjection.injectTo(cfg)
+
+        DeviceStateCenter.updateState(deviceId, ProtocolState.CONNECTING)
+        notifyState(injected.plugins, cfg, ProtocolState.CONNECTING)
+
+        val transport = transportFactory(cfg)
+        try {
+            transport.open()
+        } catch (t: Throwable) {
+            runCatching { transport.close() }
+            DeviceStateCenter.updateState(deviceId, ProtocolState.ERROR)
+            notifyState(injected.plugins, cfg, ProtocolState.ERROR)
+            injected.plugins.forEach { plugin ->
+                runCatching { plugin.onError(ModbusPluginScopes.scope(cfg, ProtocolState.ERROR), t) }
+            }
+            logger.onError(deviceId, t)
+            throw t
+        }
+
+        val device = ModbusDevice(cfg, transport, injected.interceptors, injected.plugins)
+        devices[deviceId] = device
+
+        val attachScope = ModbusPluginScopes.scope(cfg, ProtocolState.CONNECTED)
+        device.plugins.forEach { plugin ->
+            runCatching { plugin.onAttach(attachScope) }
+        }
+
+        DeviceStateCenter.updateState(deviceId, ProtocolState.CONNECTED)
+        notifyState(device.plugins, cfg, ProtocolState.CONNECTED)
+
+        DeviceStateCenter.updateState(deviceId, ProtocolState.READY)
+        notifyState(device.plugins, cfg, ProtocolState.READY)
+
+        logger.onConnect(deviceId)
+    }
+
+    override fun disconnect(deviceId: String) {
+        val device = devices.remove(deviceId) ?: return
+        device.close()
+        DeviceTaskManager.clear(deviceId)
+        DeviceStateCenter.updateState(deviceId, ProtocolState.DISCONNECTED)
+        notifyState(device.plugins, device.config, ProtocolState.DISCONNECTED)
+        val detachScope = ModbusPluginScopes.scope(device.config, ProtocolState.DISCONNECTED)
+        device.plugins.forEach { plugin ->
+            runCatching { plugin.onDetach(detachScope) }
+        }
+        logger.onDisconnect(deviceId)
+    }
+
+    override fun isConnected(deviceId: String): Boolean {
+        return devices[deviceId]?.transport?.isOpen() == true
+    }
+
+    override suspend fun send(deviceId: String, msg: CommMessage): CommMessage {
+        val device = devices[deviceId] ?: error("Device [$deviceId] not connected.")
+        if (!device.transport.isOpen()) {
+            error("Device [$deviceId] transport is closed.")
+        }
+        val cfg = device.config
+        val scope = InterceptorScope(deviceId, ProtocolType.RS485, cfg, msg)
+        val chain = InterceptorChain(scope, device.interceptors) { message ->
+            performSend(device, message)
+        }
+        return chain.proceed(msg)
+    }
+
+    private suspend fun performSend(device: ModbusDevice, message: CommMessage): CommMessage {
+        val cfg = device.config
+        val prepared = prepareRequest(cfg, message)
+        val timeoutMs = (message.metadata[ModbusMetaKeys.TIMEOUT] as? Number)?.toInt()
+            ?: cfg.requestTimeoutMs
+        val silenceGap = (message.metadata[ModbusMetaKeys.SILENCE_GAP] as? Number)?.toInt()
+            ?: cfg.responseGapMs
+        val expected = (message.metadata[ModbusMetaKeys.EXPECTED_LENGTH] as? Number)?.toInt()
+            ?: computeExpectedLength(prepared.functionCode, message)
+
+        return DeviceTaskManager.withLock(cfg.deviceId) {
+            DeviceStateCenter.updateState(cfg.deviceId, ProtocolState.BUSY)
+            notifyState(device.plugins, cfg, ProtocolState.BUSY)
+
+            val beforeScope = ModbusPluginScopes.scope(cfg, ProtocolState.BUSY, prepared.codecInput)
+            device.plugins.forEach { plugin ->
+                runCatching { plugin.onBeforeSend(beforeScope) }
+            }
+
+            try {
+                val frame = cfg.codec.encode(prepared.codecInput)
+                device.transport.write(frame)
+                val responseBytes = device.transport.readFrame(timeoutMs, expected, silenceGap)
+                val decoded = cfg.codec.decode(responseBytes)
+                val response = buildResponseMessage(message, decoded, responseBytes, prepared.headerBytes)
+
+                DeviceStateCenter.updateState(cfg.deviceId, ProtocolState.READY)
+                notifyState(device.plugins, cfg, ProtocolState.READY)
+
+                val receiveScope = ModbusPluginScopes.scope(cfg, ProtocolState.READY, response)
+                device.plugins.forEach { plugin ->
+                    runCatching { plugin.onReceive(receiveScope) }
+                }
+                response
+            } catch (t: Throwable) {
+                DeviceStateCenter.updateState(cfg.deviceId, ProtocolState.ERROR)
+                notifyState(device.plugins, cfg, ProtocolState.ERROR)
+                val errorScope = ModbusPluginScopes.scope(cfg, ProtocolState.ERROR, prepared.codecInput)
+                device.plugins.forEach { plugin ->
+                    runCatching { plugin.onError(errorScope, t) }
+                }
+                logger.onError(cfg.deviceId, t)
+                throw t
+            }
+        }
+    }
+
+    private fun prepareRequest(config: ModbusConfig, message: CommMessage): PreparedRequest {
+        val functionCode = (message.metadata[ModbusMetaKeys.FUNCTION_CODE] as? Number)?.toInt()
+        val unitId = (message.metadata[ModbusMetaKeys.UNIT_ID] as? Number)?.toInt()
+            ?: config.defaultUnitId
+
+        val header = when {
+            functionCode != null -> {
+                val id = unitId ?: error("UnitId required when functionCode is provided")
+                byteArrayOf(id.requireByte("unitId"), functionCode.requireByte("functionCode"))
+            }
+            unitId != null -> byteArrayOf(unitId.requireByte("unitId"))
+            else -> ByteArray(0)
+        }
+        val payload = header + message.payload
+        val codecInput = CommMessage(
+            command = message.command,
+            payload = payload,
+            metadata = message.metadata
+        )
+        return PreparedRequest(codecInput, header.size, functionCode)
+    }
+
+    private fun computeExpectedLength(functionCode: Int?, message: CommMessage): Int? {
+        if (functionCode == null) return null
+        val quantity = (message.metadata[ModbusMetaKeys.QUANTITY] as? Number)?.toInt()
+            ?: parseQuantity(functionCode, message.payload)
+        return when (functionCode) {
+            0x01, 0x02 -> quantity?.let { 5 + ((it + 7) / 8) }
+            0x03, 0x04 -> quantity?.let { 5 + (it * 2) }
+            0x05, 0x06 -> 8
+            0x0F, 0x10 -> 8
+            else -> null
+        }
+    }
+
+    private fun parseQuantity(functionCode: Int, payload: ByteArray): Int? {
+        return when (functionCode) {
+            0x01, 0x02, 0x03, 0x04, 0x0F, 0x10 -> if (payload.size >= 4) {
+                ((payload[2].toInt() and 0xFF) shl 8) or (payload[3].toInt() and 0xFF)
+            } else {
+                null
+            }
+            else -> null
+        }
+    }
+
+    private fun buildResponseMessage(
+        request: CommMessage,
+        decoded: CommMessage,
+        rawFrame: ByteArray,
+        headerBytes: Int
+    ): CommMessage {
+        val payload = decoded.payload
+        val metadata = request.metadata.toMutableMap()
+        metadata[ModbusMetaKeys.RAW_FRAME] = rawFrame.copyOf()
+        metadata[ModbusMetaKeys.RAW_PAYLOAD] = payload.copyOf()
+        decoded.metadata["crc"]?.let { crc ->
+            metadata[ModbusMetaKeys.CRC] = crc
+        }
+        if (payload.isNotEmpty()) {
+            metadata[ModbusMetaKeys.UNIT_ID] = payload[0].toInt() and 0xFF
+        }
+        if (payload.size >= 2) {
+            val function = payload[1].toInt() and 0xFF
+            metadata[ModbusMetaKeys.FUNCTION_CODE] = function
+            if ((function and 0x80) != 0 && payload.size >= 3) {
+                metadata[ModbusMetaKeys.EXCEPTION_CODE] = payload[2].toInt() and 0xFF
+            }
+        }
+        val strip = headerBytes.coerceAtMost(payload.size)
+        val body = payload.copyOfRange(strip, payload.size)
+        return CommMessage(
+            command = request.command,
+            payload = body,
+            metadata = metadata
+        )
+    }
+
+    override fun toString(): String {
+        return "ModbusProtocol(devices=${devices.keys})"
+    }
+
+    private fun notifyState(plugins: List<CommPlugin>, config: ModbusConfig, state: ProtocolState) {
+        val scope = ModbusPluginScopes.scope(config, state)
+        plugins.forEach { plugin ->
+            runCatching { plugin.onStateChanged(scope) }
+        }
+    }
+
+    private fun requireModbusConfig(deviceId: String): ModbusConfig {
+        return configs[deviceId]
+            ?: error("ModbusConfig for deviceId=$deviceId not registered. Call ModbusProtocol.registerConfig().")
+    }
+
+    private data class PreparedRequest(
+        val codecInput: CommMessage,
+        val headerBytes: Int,
+        val functionCode: Int?
+    )
+
+    private fun Int.requireByte(name: String): Byte {
+        require(this in 0..0xFF) { "$name out of range: $this" }
+        return toByte()
+    }
+}

--- a/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusTransport.kt
+++ b/sikcomm/src/main/java/com/sik/comm/impl_modbus/ModbusTransport.kt
@@ -1,0 +1,27 @@
+package com.sik.comm.impl_modbus
+
+import java.io.Closeable
+
+/**
+ * Modbus 传输层抽象，屏蔽 RS485 与 TCP 的差异。
+ */
+internal interface ModbusTransport : Closeable {
+
+    /** 打开底层连接。 */
+    fun open()
+
+    /** 当前传输层是否已经就绪。 */
+    fun isOpen(): Boolean
+
+    /** 写入原始帧数据。 */
+    fun write(data: ByteArray)
+
+    /**
+     * 读取一帧响应。
+     *
+     * @param timeoutMs    本次等待的最大时长
+     * @param expectedSize 若已知长度，则达到该长度即可返回
+     * @param silenceGapMs 判定帧结束的静默时长
+     */
+    fun readFrame(timeoutMs: Int, expectedSize: Int?, silenceGapMs: Int): ByteArray
+}

--- a/sikcomm/src/main/java/com/sik/comm/impl_modbus/SerialModbusTransport.kt
+++ b/sikcomm/src/main/java/com/sik/comm/impl_modbus/SerialModbusTransport.kt
@@ -1,0 +1,109 @@
+package com.sik.comm.impl_modbus
+
+import android.os.SystemClock
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.concurrent.TimeoutException
+
+/**
+ * 基于串口（RS485）的 Modbus 传输层实现。
+ */
+internal class SerialModbusTransport(
+    private val config: ModbusConfig
+) : ModbusTransport {
+
+    private var input: FileInputStream? = null
+    private var output: FileOutputStream? = null
+
+    override fun open() {
+        if (isOpen()) return
+        val portFile = File(config.portName)
+        require(portFile.exists()) { "Serial port ${config.portName} not found" }
+        try {
+            input = FileInputStream(portFile)
+            output = FileOutputStream(portFile)
+        } catch (t: Throwable) {
+            runCatching { input?.close() }
+            runCatching { output?.close() }
+            input = null
+            output = null
+            throw t
+        }
+    }
+
+    override fun isOpen(): Boolean {
+        return input != null && output != null
+    }
+
+    override fun write(data: ByteArray) {
+        val out = output ?: error("Serial port not opened.")
+        out.write(data)
+        out.flush()
+    }
+
+    override fun readFrame(timeoutMs: Int, expectedSize: Int?, silenceGapMs: Int): ByteArray {
+        val inp = input ?: error("Serial port not opened.")
+        val buffer = ByteArrayOutputStream()
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var lastRead = SystemClock.elapsedRealtime()
+        val temp = ByteArray(256)
+
+        while (true) {
+            if (SystemClock.elapsedRealtime() > deadline) {
+                if (buffer.size() == 0) {
+                    throw TimeoutException("Modbus serial read timeout: ${timeoutMs}ms")
+                }
+                break
+            }
+
+            val available = try {
+                inp.available()
+            } catch (io: IOException) {
+                throw io
+            }
+
+            if (available > 0) {
+                val toRead = available.coerceAtMost(temp.size)
+                val read = inp.read(temp, 0, toRead)
+                if (read > 0) {
+                    buffer.write(temp, 0, read)
+                    lastRead = SystemClock.elapsedRealtime()
+                    if (expectedSize != null && buffer.size() >= expectedSize) {
+                        break
+                    }
+                } else if (read < 0) {
+                    break
+                }
+            } else {
+                if (buffer.size() > 0) {
+                    val gap = SystemClock.elapsedRealtime() - lastRead
+                    if (gap >= silenceGapMs) {
+                        break
+                    }
+                }
+                try {
+                    Thread.sleep(2)
+                } catch (ie: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    break
+                }
+            }
+        }
+
+        val data = buffer.toByteArray()
+        if (data.isEmpty()) {
+            throw TimeoutException("Modbus serial read timeout: ${timeoutMs}ms")
+        }
+        return data
+    }
+
+    override fun close() {
+        runCatching { input?.close() }
+        runCatching { output?.close() }
+        input = null
+        output = null
+    }
+}

--- a/sikcomm/src/main/java/com/sik/comm/impl_modbus/TcpModbusTransport.kt
+++ b/sikcomm/src/main/java/com/sik/comm/impl_modbus/TcpModbusTransport.kt
@@ -1,0 +1,104 @@
+package com.sik.comm.impl_modbus
+
+import android.os.SystemClock
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.util.concurrent.TimeoutException
+
+/**
+ * 基于 TCP 的 Modbus 传输层。
+ */
+internal class TcpModbusTransport(
+    private val host: String,
+    private val port: Int,
+    private val connectTimeoutMs: Int
+) : ModbusTransport {
+
+    private var socket: Socket? = null
+
+    override fun open() {
+        if (isOpen()) return
+        val s = Socket()
+        try {
+            s.connect(InetSocketAddress(host, port), connectTimeoutMs)
+            s.tcpNoDelay = true
+            socket = s
+        } catch (t: Throwable) {
+            runCatching { s.close() }
+            throw t
+        }
+    }
+
+    override fun isOpen(): Boolean {
+        val s = socket
+        return s != null && s.isConnected && !s.isClosed
+    }
+
+    override fun write(data: ByteArray) {
+        val s = socket ?: error("TCP socket not opened.")
+        try {
+            val out = s.getOutputStream()
+            out.write(data)
+            out.flush()
+        } catch (io: IOException) {
+            throw io
+        }
+    }
+
+    override fun readFrame(timeoutMs: Int, expectedSize: Int?, silenceGapMs: Int): ByteArray {
+        val s = socket ?: error("TCP socket not opened.")
+        val input = s.getInputStream()
+        val buffer = ByteArrayOutputStream()
+        val temp = ByteArray(256)
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        var lastRead = SystemClock.elapsedRealtime()
+        s.soTimeout = silenceGapMs.coerceAtLeast(1)
+
+        while (true) {
+            if (SystemClock.elapsedRealtime() > deadline) {
+                if (buffer.size() == 0) {
+                    throw TimeoutException("Modbus TCP read timeout: ${timeoutMs}ms")
+                }
+                break
+            }
+
+            try {
+                val read = input.read(temp, 0, temp.size)
+                if (read > 0) {
+                    buffer.write(temp, 0, read)
+                    lastRead = SystemClock.elapsedRealtime()
+                    if (expectedSize != null && buffer.size() >= expectedSize) {
+                        break
+                    }
+                } else if (read < 0) {
+                    break
+                }
+            } catch (e: SocketTimeoutException) {
+                if (buffer.size() > 0) {
+                    break
+                }
+            }
+
+            if (buffer.size() > 0) {
+                val gap = SystemClock.elapsedRealtime() - lastRead
+                if (gap >= silenceGapMs) {
+                    break
+                }
+            }
+        }
+
+        val data = buffer.toByteArray()
+        if (data.isEmpty()) {
+            throw TimeoutException("Modbus TCP read timeout: ${timeoutMs}ms")
+        }
+        return data
+    }
+
+    override fun close() {
+        runCatching { socket?.close() }
+        socket = null
+    }
+}


### PR DESCRIPTION
## Summary
- add a full Modbus protocol implementation integrating with DeviceTaskManager, plugins, and interceptors
- provide TCP and serial transport abstractions plus metadata helpers for Modbus-specific context
- extend ModbusConfig with codec, timeout, and plugin/interceptor hooks

## Testing
- ./gradlew :sikcomm:compileDebugKotlin *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ede7d95c98832ebce41a4649dcdc54